### PR TITLE
added example scripts for storing ans retrieving data from cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ This repository contains:
 - [`log_another_flow_with_search.js`](example_scripts/log_another_flow_with_search.js) - Search for previous flow executions using executionSearchByPartner
 - [`process_x12_997_files.js`](example_scripts/process_x12_997_files.js) - Parse and validate X12 997 EDI acknowledgment files
 - [`get_newest_file_from_partner_execution.js`](example_scripts/get_newest_file_from_partner_execution.js) - Retrieve the newest file from a partner's most recent tagged execution
+- [`store_values_in_preprocessor.js`](example_scripts/store_values_in_preprocessor.js) - Store values in execution context for use in postprocessor
+- [`retrieve_values_in_postprocessor.js`](example_scripts/retrieve_values_in_postprocessor.js) - Retrieve values from execution context in postprocessor
 
 ## Table of Contents
 - [Quick Start](#quick-start)

--- a/example_scripts/retrieve_values_in_postprocessor.js
+++ b/example_scripts/retrieve_values_in_postprocessor.js
@@ -1,0 +1,21 @@
+const handleFile = (file) => {
+  const orders = JSON.parse(file.body)
+  const orderNumber = orders.orderNumber
+
+  const orderReference = executionContext[orderNumber].orderReference
+  const orderCount = executionContext[orderNumber].orderCount
+  const totalValue = executionContext[orderNumber].totalValue
+  const processedAt = executionContext[orderNumber].processedAt
+
+  userLog(`Processed ${orderCount} order(s) ${orderNumber} with a total value of ${totalValue} at ${processedAt}`)
+
+  return { ...file, file_name: `${orderReference}_processed.json` }
+}
+
+const updatedFiles = destinationFiles.map(handleFile).filter(x => x)
+
+if (updatedFiles.length === 0) {
+  returnSkipped([])
+} else {
+  returnSuccess(updatedFiles)
+}

--- a/example_scripts/store_values_in_preprocessor.js
+++ b/example_scripts/store_values_in_preprocessor.js
@@ -1,0 +1,23 @@
+/**
+ * Chain.io Pre-Processor for storing input file values for accessibility in post-processor
+ *
+ * Features:
+ * - Parse the JSON body of each file
+ * - Store the reference, order count, total value, and processed timestamp for each order by order number in executionContext
+ */
+const storeValues = (file) => {
+  const orders = JSON.parse(file.body)
+
+  const orderNumber = orders.orderNumber
+
+  executionContext[orderNumber].orderReference = orders.reference
+  executionContext[orderNumber].orderCount = orders.length
+  executionContext[orderNumber].totalValue = orders.reduce((sum, order) => sum + (order.value || 0), 0)
+  executionContext[orderNumber].processedAt = new Date().toISOString()
+}
+
+for (const sourceFile of sourceFiles) {
+  storeValues(sourceFile)
+}
+
+returnSuccess(sourceFiles)


### PR DESCRIPTION
# PR Summary: Example Scripts for Storing and Retrieving Data via `executionContext`

## Branch
`1907` → `main`

## Overview
Adds two example scripts demonstrating how to pass data between a pre-processor and a post-processor using the shared `executionContext` object within a Chain.io integration pipeline.

## Changes

### New Files (2)

#### `example_scripts/store_values_in_preprocessor.js`
A pre-processor script that parses incoming JSON order files and stores key values into `executionContext`, keyed by `orderNumber`, for downstream use in a post-processor.

Values stored per order:
- `orderReference` — the order's reference identifier
- `orderCount` — the number of items in the order (`orders.length`)
- `totalValue` — sum of all `order.value` fields
- `processedAt` — ISO timestamp of when the file was processed

#### `example_scripts/retrieve_values_in_postprocessor.js`
A post-processor script that reads the values stored in `executionContext` by the pre-processor and uses them to:
- Log a summary via `userLog` (order count, order number, total value, and timestamp)
- Rename the output file to `{orderReference}_processed.json`

Returns `returnSkipped` if no files are produced, otherwise `returnSuccess`.

## Motivation
Demonstrates a common pattern for sharing computed or derived data across processor stages in a Chain.io pipeline without duplicating parsing logic or relying on external state.

## File Diff Summary

| File | Status | Lines Added |
|------|--------|-------------|
| `example_scripts/store_values_in_preprocessor.js` | Added | +23 |
| `example_scripts/retrieve_values_in_postprocessor.js` | Added | +21 |

**Total: 2 files changed, 44 insertions(+)**
